### PR TITLE
Factored out source code analysis logic (for capturing angular module dependencies)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var es = require('event-stream');
 var esprima = require('esprima');
 var estraverse  = require('estraverse');
+var ngDep = require('ng-dependencies');
 
 module.exports = function angularFilesort () {
   var files = [];
@@ -8,42 +9,17 @@ module.exports = function angularFilesort () {
   var indexCache = {};
 
   return es.through(function (file) {
-      var declared = [],
-          used = [];
+      var deps = ngDep(file.contents);
 
-      estraverse.traverse(esprima.parse(file.contents), {
-        leave: function (node, parent) {
-          if (!isAngularModuleStatement(node)) {
-            return;
-          }
-          var moduleName = parent.arguments[0].value;
-          if (parent.arguments[1]) {
-            if (declared.indexOf(moduleName) < 0) {
-              declared.push(moduleName);
-              if (used.indexOf(moduleName) > -1) {
-                used.splice(used.indexOf(moduleName), 1);
-              }
-            }
-            parent.arguments[1].elements.forEach(function (el) {
-              if (used.indexOf(el.value) < 0) {
-                used.push(el.value);
-              }
-            });
-          } else if (declared.indexOf(moduleName) < 0 && used.indexOf(moduleName) < 0) {
-            used.push(moduleName);
-          }
+      for (var i = 0; i < deps.length; i++) {
+        var d = deps[i];
+        d.file = file;
+        if (typeof d.name !== 'undefined') {
+          angmods[d.name] = d;
+        } else {
+          files.push(d);
         }
-      });
-
-      for (var d = 0; d < declared.length; d++) {
-        angmods[declared[d]] = {
-          file: file,
-          name: declared[d],
-          uses: used
-        };
       }
-
-      files.push({file: file, uses: used});
     }, function () {
       var sorter = sortIndex.bind(null, indexCache, angmods);
 
@@ -63,10 +39,6 @@ module.exports = function angularFilesort () {
       this.emit('end');
     });
 };
-
-function isAngularModuleStatement (node) {
-  return node.type === 'MemberExpression' && node.object.name === 'angular' && node.property.name === 'module';
-}
 
 function sortIndex (cache, angmods, obj) {
   if (typeof cache[obj.file.relative] !== 'undefined') {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "estraverse": "~1.5.0",
     "esprima": "~1.1.1",
-    "event-stream": "~3.1.1"
+    "event-stream": "~3.1.1",
+    "ng-dependencies": "0.0.1"
   }
 }


### PR DESCRIPTION
I needed the portion of code that analyze the angular module dependencies, so I created a different NPM module for it https://github.com/blai/ng-dependencies. I also fixed a couple of use cases, see the [unit tests](https://github.com/blai/ng-dependencies/blob/master/test/index_test.js) for detail.

Would you allow me to hand over the ownership of https://github.com/blai/ng-dependencies back to you? (since the source code were yours anyway).

By the way, would it be possible for the sorting algorithm not depend on `relative` of `file`, but purely on `file.content`? (https://github.com/klei/gulp-angular-filesort/blob/master/index.js#L55 and https://github.com/klei/gulp-angular-filesort/blob/master/index.js#L73), this way we can also factor out the sorting logic (I found other purpose of using it a little differently).
