### PR TITLE
Properly Handle ng-dependencies Errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,11 @@
 var es = require('event-stream');
 var ngDep = require('ng-dependencies');
 var toposort = require('toposort');
+var gutil = require('gulp-util');
+var PluginError = gutil.PluginError;
 
 var ANGULAR_MODULE = 'ng';
+const PLUGIN_NAME = 'gulp-angular-filesort';
 
 module.exports = function angularFilesort () {
   var files = [];
@@ -10,7 +13,12 @@ module.exports = function angularFilesort () {
   var toSort = [];
 
   return es.through(function collectFilesToSort (file) {
-      var deps = ngDep(file.contents);
+      var deps;
+      try {
+        deps = ngDep(file.contents);
+      } catch (err) {
+        return this.emit('error', new PluginError(PLUGIN_NAME, "Error in compiling: " + file.relative + ": " + err.message));
+      }
 
       if (deps.modules) {
         // Store references to each file with a declaration:


### PR DESCRIPTION
Previously any pipeline would break on error, even if gulp-plumber was used.

This allows for proper stream error handling
