### PR TITLE
CoffeeScript

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
+var coffee = require('coffee-script');
 var es = require('event-stream');
 var ngDep = require('ng-dependencies');
 var toposort = require('toposort');
 var gutil = require('gulp-util');
+var path = require('path');
 var PluginError = gutil.PluginError;
 
 var PLUGIN_NAME = 'gulp-angular-filesort';
@@ -15,6 +17,9 @@ module.exports = function angularFilesort () {
   return es.through(function collectFilesToSort (file) {
       var deps;
       try {
+        if (path.extname(file.path) === '.coffee') {
+          file.contents = new Buffer(coffee.compile(file.contents.toString('utf8')));
+        }
         deps = ngDep(file.contents);
       } catch (err) {
         return this.emit('error', new PluginError(PLUGIN_NAME, 'Error in parsing: "' + file.relative + '", ' + err.message));

--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
     "mocha": "~1.18.2"
   },
   "dependencies": {
-    "gulp-util": "^3.0.0",
+    "coffee-script": "^1.8.0",
     "event-stream": "^3.1.1",
+    "gulp-util": "^3.0.0",
     "ng-dependencies": "~0.1.1",
     "toposort": "~0.2.10"
   }

--- a/test/angularFilesort_test.js
+++ b/test/angularFilesort_test.js
@@ -123,4 +123,42 @@ describe('gulp-angular-filesort', function () {
 
     stream.end();
   });
+
+  it('should sort CoffeeScript and JavaScript', function (done) {
+    var files = [
+      fixture(path.join('fixtures', 'coffee-module.coffee')),
+      fixture(path.join('fixtures', 'another-factory.js')),
+      fixture(path.join('fixtures', 'module.js')),
+      fixture(path.join('fixtures', 'yet-another.js')),
+      fixture(path.join('fixtures', 'another.js'))
+    ];
+
+    var resultFiles = [];
+    var error = null;
+
+    var stream = angularFilesort();
+
+    stream.on('error', function(err) {
+      error = err;
+    });
+
+    stream.on('data', function (file) {
+      resultFiles.push(file.relative);
+    });
+
+    stream.on('end', function () {
+      resultFiles.length.should.equal(5);
+      resultFiles.indexOf(path.join('fixtures', 'yet-another.js')).should.be.above(resultFiles.indexOf(path.join('fixtures', 'coffee-module.js')));
+      resultFiles.indexOf(path.join('fixtures', 'yet-another.js')).should.be.above(resultFiles.indexOf(path.join('fixtures', 'another.js')));
+      resultFiles.indexOf(path.join('fixtures', 'module.js')).should.be.above(resultFiles.indexOf(path.join('fixtures', 'another.js')));
+      resultFiles.indexOf(path.join('fixtures', 'another-factory.js')).should.be.above(resultFiles.indexOf(path.join('fixtures', 'another.js')));
+      done();
+    });
+
+    files.forEach(function (file) {
+      stream.write(file);
+    });
+
+    stream.end();
+  });
 });

--- a/test/angularFilesort_test.js
+++ b/test/angularFilesort_test.js
@@ -21,13 +21,13 @@ describe('gulp-angular-filesort', function () {
   it('should sort file with a module definition before files that uses it', function (done) {
 
     var files = [
-      fixture('fixtures/another-factory.js'),
-      fixture('fixtures/another.js'),
-      fixture('fixtures/module-controller.js'),
-      fixture('fixtures/no-deps.js'),
-      fixture('fixtures/module.js'),
-      fixture('fixtures/dep-on-non-declared.js'),
-      fixture('fixtures/yet-another.js')
+      fixture(path.join('fixtures', 'another-factory.js')),
+      fixture(path.join('fixtures', 'another.js')),
+      fixture(path.join('fixtures', 'module-controller.js')),
+      fixture(path.join('fixtures', 'no-deps.js')),
+      fixture(path.join('fixtures', 'module.js')),
+      fixture(path.join('fixtures', 'dep-on-non-declared.js')),
+      fixture(path.join('fixtures', 'yet-another.js'))
     ];
 
     var resultFiles = [];
@@ -45,9 +45,9 @@ describe('gulp-angular-filesort', function () {
 
     stream.on('end', function () {
       resultFiles.length.should.equal(7);
-      resultFiles.indexOf('fixtures/module-controller.js').should.be.above(resultFiles.indexOf('fixtures/module.js'));
-      resultFiles.indexOf('fixtures/yet-another.js').should.be.above(resultFiles.indexOf('fixtures/another.js'));
-      resultFiles.indexOf('fixtures/another-factory.js').should.be.above(resultFiles.indexOf('fixtures/another.js'));
+      resultFiles.indexOf(path.join('fixtures', 'module-controller.js')).should.be.above(resultFiles.indexOf(path.join('fixtures', 'module.js')));
+      resultFiles.indexOf(path.join('fixtures', 'yet-another.js')).should.be.above(resultFiles.indexOf(path.join('fixtures', 'another.js')));
+      resultFiles.indexOf(path.join('fixtures', 'another-factory.js')).should.be.above(resultFiles.indexOf(path.join('fixtures', 'another.js')));
       done();
     });
 
@@ -60,7 +60,7 @@ describe('gulp-angular-filesort', function () {
 
   it('should not crash when a module is both declared and used in the same file (Issue #5)', function (done) {
     var files = [
-      fixture('fixtures/circular.js')
+      fixture(path.join('fixtures', 'circular.js'))
     ];
 
     var resultFiles = [];
@@ -78,7 +78,7 @@ describe('gulp-angular-filesort', function () {
 
     stream.on('end', function () {
       resultFiles.length.should.equal(1);
-      resultFiles[0].should.equal('fixtures/circular.js');
+      resultFiles[0].should.equal(path.join('fixtures', 'circular.js'));
       should.not.exist(error);
       done();
     });
@@ -92,8 +92,8 @@ describe('gulp-angular-filesort', function () {
 
   it('should not crash when a module is used inside a declaration even though it\'s before that module\'s declaration (Issue #7)', function (done) {
     var files = [
-      fixture('fixtures/circular2.js'),
-      fixture('fixtures/circular3.js')
+      fixture(path.join('fixtures', 'circular2.js')),
+      fixture(path.join('fixtures', 'circular3.js'))
     ];
 
     var resultFiles = [];
@@ -111,8 +111,8 @@ describe('gulp-angular-filesort', function () {
 
     stream.on('end', function () {
       resultFiles.length.should.equal(2);
-      resultFiles.should.contain('fixtures/circular2.js');
-      resultFiles.should.contain('fixtures/circular3.js');
+      resultFiles.should.contain(path.join('fixtures', 'circular2.js'));
+      resultFiles.should.contain(path.join('fixtures', 'circular3.js'));
       should.not.exist(error);
       done();
     });

--- a/test/fixtures/coffee-module.coffee
+++ b/test/fixtures/coffee-module.coffee
@@ -1,0 +1,2 @@
+
+angular.module 'coffee', ['yet-another']


### PR DESCRIPTION
I'm not experienced with writing Gulp plugins, so I apologize in advance for any major errors.

This pull request also contains the changes from #10. If #10 is to be rejected, I can remove those changes from this pull request.

These changes will compile CoffeeScript before sending the file contents to ng-dependencies if the file extension ends with .coffee.

The reasoning for creating this is for injecting files in the correct order into Karma.config.js, etc. This is preferred over compiling CoffeeScript files into temp files for testing.