### PR TITLE
Prevent read errors for non-js files

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,14 @@ module.exports = function angularFilesort () {
 
   return es.through(function collectFilesToSort (file) {
       var deps;
+
+	  // prevent read errors for non-js files
+	  if (!file.relative.match(/.+\.js$/)) {
+		  // still need to add the file though
+		  files.push(file);
+		  return;
+	  }
+
       try {
         deps = ngDep(file.contents);
       } catch (err) {


### PR DESCRIPTION
Had issues when file list contains css files which can be the case when using the main-bower-files gulp plugin. Angular material has a css file which resulted in a read error, this fixed it. 