### PR TITLE
Fixes klei/gulp-angular-filesort#17

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function angularFilesort () {
       if (deps.dependencies) {
         // Add each file with dependencies to the array to sort:
         deps.dependencies.forEach(function (dep) {
-          if (isDependecyUsedInAnyDeclaration(dep, deps)) {
+          if (isDependencyUsedInAnyDeclaration(dep, deps)) {
             return;
           }
           if (dep === ANGULAR_MODULE) {
@@ -61,6 +61,11 @@ module.exports = function angularFilesort () {
         }
       }
 
+      // Sort `files` per path so files with same tree position after toposort are always sent back in the same order
+      files.sort(function(f1, f2) {
+        return f1.path < f2.path;
+      });
+
       // Sort `files` with `toSort` as dependency tree:
       toposort.array(files, toSort)
         .reverse()
@@ -72,7 +77,7 @@ module.exports = function angularFilesort () {
     });
 };
 
-function isDependecyUsedInAnyDeclaration (dependency, ngDeps) {
+function isDependencyUsedInAnyDeclaration (dependency, ngDeps) {
   if (!ngDeps.modules) {
     return false;
   }

--- a/test/angularFilesort_test.js
+++ b/test/angularFilesort_test.js
@@ -69,6 +69,30 @@ describe('gulp-angular-filesort', function () {
 
   });
 
+  it('should sort the same set of files the same way independently of the order they are sent', function (done) {
+
+    var files = [
+      fixture('fixtures/another-factory.js'),
+      fixture('fixtures/another.js'),
+      fixture('fixtures/module-controller.js'),
+      fixture('fixtures/no-deps.js'),
+      fixture('fixtures/module.js'),
+      fixture('fixtures/dep-on-non-declared.js'),
+      fixture('fixtures/yet-another.js')
+    ];
+
+    sort(files, function (resultFiles) {
+      resultFiles.length.should.equal(7);
+      files.reverse();
+      sort(files, function (resultFiles2) {
+        resultFiles2.length.should.equal(7);
+        resultFiles2.should.deep.equal(resultFiles);
+        done();
+      })
+    })
+
+  });
+
   it('should not crash when a module is both declared and used in the same file (Issue #5)', function (done) {
     var files = [
       fixture('fixtures/circular.js')


### PR DESCRIPTION
It looks the issue is not really with toposort. With the same input, I always get the same order back.
Though, gulp.src can send files in different orders, so sorting the files before toposort does the trick
Also, fixed some minor typos :)
