### PR TITLE
Adding the possibility to exclude files from the reordering and put them at the start of the stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea

--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ gulp.src('./src/app/index.html')
   ))
   .pipe(gulp.dest('./build'));
 ```
+Using the option to exclude files
+
+```javascript
+var angularFilesort = require('gulp-angular-filesort'),
+    inject = require('gulp-inject');
+
+gulp.src('./src/app/index.html')
+  .pipe(inject(
+    gulp.src(['./src/app/**/*.js']).pipe(angularFilesort({exclude:'src/app/.*test*'}))
+  ))
+  .pipe(gulp.dest('./build'));
+```
+
+### Options
+An opject with options can be passed into angular-filesort.
+
+#### exclude
+The exclude option takes a string that will be used to create a regular expression. If a file path matches
+this expression, it will not be processed and put at the beginning of the stream.
 
 **NOTE** Do not use the `read` option for `gulp.src`! This plugin analyzes the contents of each file to determine sort order.
 

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function angularFilesort (options) {
       if (deps.dependencies) {
         // Add each file with dependencies to the array to sort:
         deps.dependencies.forEach(function (dep) {
-          if (isDependecyUsedInAnyDeclaration(dep, deps)) {
+          if (isDependencyUsedInAnyDeclaration(dep, deps)) {
             return;
           }
           if (dep === ANGULAR_MODULE) {
@@ -68,6 +68,12 @@ module.exports = function angularFilesort (options) {
           toSort.splice(i--, 1);
         }
       }
+      // sort the start files alphabetically
+      start.sort(function(a, b) {
+          if(a.path < b.path) return -1;
+          if(a.path > b.path) return 1;
+          return 0;
+      });
       //first emit start files
       start.forEach(function(file) {
         this.emit('data', file);
@@ -83,7 +89,7 @@ module.exports = function angularFilesort (options) {
     });
 };
 
-function isDependecyUsedInAnyDeclaration (dependency, ngDeps) {
+function isDependencyUsedInAnyDeclaration (dependency, ngDeps) {
   if (!ngDeps.modules) {
     return false;
   }

--- a/index.js
+++ b/index.js
@@ -12,16 +12,16 @@ module.exports = function angularFilesort (options) {
   var start = [];
   var angmods = {};
   var toSort = [];
-  var putatstart = false;
-  if (typeof options != 'undefined' && typeof options.putatstart != 'undefined') {
-    putatstart = new RegExp(options.putatstart, 'i');
+  var exclude = false;
+  if (typeof options != 'undefined' && typeof options.exclude != 'undefined') {
+    exclude = new RegExp(options.exclude, 'i');
   }
 
   return es.through(function collectFilesToSort (file) {
       if(!file.contents) {
         return this.emit('error', new PluginError(PLUGIN_NAME, 'File: "' + file.relative + '" without content. You have to read it with gulp.src(..)'));
       }
-      if (putatstart && file.path.match(putatstart)) {
+      if (exclude && file.path.match(exclude)) {
         start.push(file);
         return;
       }

--- a/test/angularFilesort_test.js
+++ b/test/angularFilesort_test.js
@@ -17,14 +17,14 @@ function fixture(file, config) {
   });
 }
 
-function sort(files, checkResults, hadleError) {
+function sort(files, options, checkResults, handleError) {
   var resultFiles = [];
 
-  var stream = angularFilesort();
+  var stream = angularFilesort(options);
 
   stream.on('error', function (err) {
-    if (hadleError) {
-      hadleError(err);
+    if (handleError) {
+      handleError(err);
     } else {
       should.exist(err);
       done(err);
@@ -59,7 +59,7 @@ describe('gulp-angular-filesort', function () {
       fixture('fixtures/yet-another.js')
     ];
 
-    sort(files, function (resultFiles) {
+    sort(files, {}, function (resultFiles) {
       resultFiles.length.should.equal(7);
       resultFiles.indexOf('fixtures/module-controller.js').should.be.above(resultFiles.indexOf('fixtures/module.js'));
       resultFiles.indexOf('fixtures/yet-another.js').should.be.above(resultFiles.indexOf('fixtures/another.js'));
@@ -74,7 +74,7 @@ describe('gulp-angular-filesort', function () {
       fixture('fixtures/circular.js')
     ];
 
-    sort(files, function (resultFiles) {
+    sort(files, {}, function (resultFiles) {
       resultFiles.length.should.equal(1);
       resultFiles[0].should.equal('fixtures/circular.js');
       done();
@@ -88,7 +88,7 @@ describe('gulp-angular-filesort', function () {
       fixture('fixtures/circular3.js')
     ];
 
-    sort(files, function (resultFiles) {
+    sort(files, {}, function (resultFiles) {
       resultFiles.length.should.equal(2);
       resultFiles.should.contain('fixtures/circular2.js');
       resultFiles.should.contain('fixtures/circular3.js');
@@ -102,7 +102,7 @@ describe('gulp-angular-filesort', function () {
       fixture('fake.js', {withoutContents: true})
     ];
 
-    sort(files, function () {
+    sort(files, {}, function () {
     }, function (err) {
       should.exist(err);
       done()
@@ -114,8 +114,28 @@ describe('gulp-angular-filesort', function () {
       fixture('fixtures/empty.js')
     ];
 
-    sort(files, function (resultFiles) {
-      resultFiles.should.eql(['fixtures/empty.js'])
+    sort(files, {}, function (resultFiles) {
+      resultFiles.should.eql(['fixtures/empty.js']);
+      done();
+    })
+  });
+
+  it('exclude should work and sort the excluded files', function (done) {
+    var files = [
+      fixture('fixtures/another.js'),
+      fixture('fixtures/dep-on-non-declared.js'),
+      fixture('fixtures/circular3.js'),
+      fixture('fixtures/circular2.js'),
+      fixture('fixtures/circular.js'),
+      fixture('fixtures/no-deps.js'),
+      fixture('fixtures/empty.js')
+    ];
+
+    sort(files, {exclude: ".*circular.*"}, function (resultFiles) {
+      resultFiles.length.should.equal(7);
+      resultFiles[0].should.equal('fixtures/circular.js');
+      resultFiles[1].should.equal('fixtures/circular2.js');
+      resultFiles[2].should.equal('fixtures/circular3.js');
       done();
     })
   });


### PR DESCRIPTION
I had the problem when I was building an angular app with typescript that I wanted to make an abstract service, that a few other services extend from. Using angular-filesort this base class always ended up lower in the stream and therefore I ran into an error "Cannot read property 'prototype' of undefined" when the classes tried to extend from the base class.

With this fix it is possible to pass in a regular expression to exclude files from the reordering based on angular dependencies.