### PR TITLE
Don't reverse array is there is nothing to sort.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = function angularFilesort () {
   var files = [];
   var angmods = {};
   var toSort = [];
+  var dependencyUndefined = false;
 
   return es.through(function collectFilesToSort (file) {
       if(!file.contents) {
@@ -34,6 +35,10 @@ module.exports = function angularFilesort () {
       if (deps.dependencies) {
         // Add each file with dependencies to the array to sort:
         deps.dependencies.forEach(function (dep) {
+          if(dep == undefined){
+            dependencyUndefined = true;
+            return;
+          }
           if (isDependecyUsedInAnyDeclaration(dep, deps)) {
             return;
           }
@@ -64,7 +69,7 @@ module.exports = function angularFilesort () {
       // Sort `files` with `toSort` as dependency tree:
       var sorted = toposort.array(files, toSort);
 
-      if(toSort.length){
+      if(toSort.length || dependencyUndefined){
         sorted.reverse()
       }
 

--- a/index.js
+++ b/index.js
@@ -62,11 +62,15 @@ module.exports = function angularFilesort () {
       }
 
       // Sort `files` with `toSort` as dependency tree:
-      toposort.array(files, toSort)
-        .reverse()
-        .forEach(function (file) {
-          this.emit('data', file);
-        }.bind(this));
+      var sorted = toposort.array(files, toSort);
+
+      if(toSort.length){
+        sorted.reverse()
+      }
+
+      sorted.forEach(function (file) {
+        this.emit('data', file);
+      }.bind(this));
 
       this.emit('end');
     });


### PR DESCRIPTION
I believe this resolves issue many folks are having. The original code made the assumption that the files passed to angular-file-sort are not in the correct order (unlikely but does occur). Reversing of the array should only occur if toSort has some elements in it. 

I believe this PR address #30 #27 please look over this and let me know if I am correct in my analysis
