### PR TITLE
Initial Alphabetic Sorting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+insert_final_newline = false
+trim_trailing_whitespace = false

--- a/index.js
+++ b/index.js
@@ -78,6 +78,14 @@ module.exports = function angularFilesort() {
       }
     }
 
+    // Sort files alphabetically first to prevent random reordering.
+    // Reverse sorting as it is reversed later on.
+    files.sort(function (a, b) {
+        if(a.path.toLowerCase().replace(a.extname, '') < b.path.toLowerCase().replace(b.extname, '')) return 1;
+        if(a.path.toLowerCase().replace(a.extname, '') > b.path.toLowerCase().replace(b.extname, '')) return -1;
+        return 0;
+    });
+
     // Sort `files` with `toSort` as dependency tree:
     toposort.array(files, toSort)
       .reverse()

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "gulp-util": "^3.0.7",
-    "ng-dependencies": "^0.5.0",
+    "ng-dependencies": "^0.7.0",
     "through2": "^2.0.0",
     "toposort": "^1.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
   },
   "homepage": "https://github.com/klei/gulp-angular-filesort",
   "devDependencies": {
-    "chai": "~3.3.0",
-    "mocha": "~2.3.3"
+    "chai": "^3.5.0",
+    "mocha": "^2.4.5"
   },
   "dependencies": {
     "gulp-util": "^3.0.7",
-    "ng-dependencies": "~0.3.0",
+    "ng-dependencies": "^0.5.0",
     "through2": "^2.0.0",
-    "toposort": "~0.2.12"
+    "toposort": "^1.0.0"
   }
 }

--- a/test/angularFilesort_test.js
+++ b/test/angularFilesort_test.js
@@ -17,14 +17,14 @@ function fixture(file, config) {
   });
 }
 
-function sort(files, checkResults, hadleError) {
+function sort(files, checkResults, handleError) {
   var resultFiles = [];
 
   var stream = angularFilesort();
 
   stream.on('error', function (err) {
-    if (hadleError) {
-      hadleError(err);
+    if (handleError) {
+      handleError(err);
     } else {
       should.exist(err);
       done(err);
@@ -48,7 +48,6 @@ function sort(files, checkResults, hadleError) {
 
 describe('gulp-angular-filesort', function () {
   it('should sort file with a module definition before files that uses it', function (done) {
-
     var files = [
       fixture('fixtures/another-factory.js'),
       fixture('fixtures/another.js'),
@@ -66,7 +65,25 @@ describe('gulp-angular-filesort', function () {
       resultFiles.indexOf('fixtures/another-factory.js').should.be.above(resultFiles.indexOf('fixtures/another.js'));
       done();
     })
+  });
 
+  it('should sort files alphabetically when no ordering is required', function (done) {
+      var files = [
+          fixture('fixtures/module.js'),
+          fixture('fixtures/circular3.js'),
+          fixture('fixtures/module-controller.js'),
+          fixture('fixtures/circular.js'),
+          fixture('fixtures/circular2.js'),
+      ];
+
+      sort(files, function (resultFiles) {
+          resultFiles.length.should.equal(5);
+          resultFiles.indexOf('fixtures/module-controller.js').should.be.above(resultFiles.indexOf('fixtures/module.js'));
+          resultFiles.indexOf('fixtures/module.js').should.be.above(resultFiles.indexOf('fixtures/circular.js'));
+          resultFiles.indexOf('fixtures/circular3.js').should.be.above(resultFiles.indexOf('fixtures/circular2.js'));
+          resultFiles.indexOf('fixtures/circular3.js').should.be.above(resultFiles.indexOf('fixtures/circular.js'));
+          done();
+      })
   });
 
   it('should not crash when a module is both declared and used in the same file (Issue #5)', function (done) {
@@ -79,7 +96,6 @@ describe('gulp-angular-filesort', function () {
       resultFiles[0].should.equal('fixtures/circular.js');
       done();
     })
-
   });
 
   it('should not crash when a module is used inside a declaration even though it\'s before that module\'s declaration (Issue #7)', function (done) {
@@ -94,7 +110,6 @@ describe('gulp-angular-filesort', function () {
       resultFiles.should.contain('fixtures/circular3.js');
       done();
     })
-
   });
 
   it('fails for not read file', function (done) {


### PR DESCRIPTION
Hey there,

We've been using this plugin on some projects where setting up Webpack/Broweserify didn't seem worthwhile. The only gripe we have is that the ordering of files seems non-deterministic besides the module definition. This creates pointless changes in git when switching branches for example, which can be annoying. To avoid this I sort the files alphabetically first before the dependency sorting.

I also updated the dependencies and added a editorconfig, hope this is not too much.

Kind regards