### PR TITLE
Bump ng-dependencies to v0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "gulp-util": "^3.0.7",
-    "ng-dependencies": "~0.3.0",
+    "ng-dependencies": "~0.7.0",
     "through2": "^2.0.0",
     "toposort": "~0.2.12"
   }


### PR DESCRIPTION
Allows usage of Arrow functions without transpiling