### PR TITLE
Drop dependency on deprecated `gulp-util`

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,7 @@
 var through = require('through2');
 var ngDep = require('ng-dependencies');
 var toposort = require('toposort');
-var gutil = require('gulp-util');
-var PluginError = gutil.PluginError;
+var PluginError = require('plugin-error');
 
 var PLUGIN_NAME = 'gulp-angular-filesort';
 var ANGULAR_MODULE = 'ng';

--- a/package.json
+++ b/package.json
@@ -24,11 +24,12 @@
   "homepage": "https://github.com/klei/gulp-angular-filesort",
   "devDependencies": {
     "chai": "^3.5.0",
-    "mocha": "^2.4.5"
+    "mocha": "^2.4.5",
+    "vinyl": "^2.1.0"
   },
   "dependencies": {
-    "gulp-util": "^3.0.7",
     "ng-dependencies": "^0.7.0",
+    "plugin-error": "^0.1.2",
     "through2": "^2.0.0",
     "toposort": "^1.0.0"
   }

--- a/test/angularFilesort_test.js
+++ b/test/angularFilesort_test.js
@@ -60,9 +60,9 @@ describe('gulp-angular-filesort', function () {
 
     sort(files, function (resultFiles) {
       resultFiles.length.should.equal(7);
-      resultFiles.indexOf('fixtures/module-controller.js').should.be.above(resultFiles.indexOf('fixtures/module.js'));
-      resultFiles.indexOf('fixtures/yet-another.js').should.be.above(resultFiles.indexOf('fixtures/another.js'));
-      resultFiles.indexOf('fixtures/another-factory.js').should.be.above(resultFiles.indexOf('fixtures/another.js'));
+      resultFiles.indexOf(path.join('fixtures','module-controller.js')).should.be.above(resultFiles.indexOf(path.join('fixtures','module.js')));
+      resultFiles.indexOf(path.join('fixtures','yet-another.js')).should.be.above(resultFiles.indexOf(path.join('fixtures','another.js')));
+      resultFiles.indexOf(path.join('fixtures','another-factory.js')).should.be.above(resultFiles.indexOf(path.join('fixtures','another.js')));
       done();
     })
   });
@@ -78,10 +78,10 @@ describe('gulp-angular-filesort', function () {
 
       sort(files, function (resultFiles) {
           resultFiles.length.should.equal(5);
-          resultFiles.indexOf('fixtures/module-controller.js').should.be.above(resultFiles.indexOf('fixtures/module.js'));
-          resultFiles.indexOf('fixtures/module.js').should.be.above(resultFiles.indexOf('fixtures/circular.js'));
-          resultFiles.indexOf('fixtures/circular3.js').should.be.above(resultFiles.indexOf('fixtures/circular2.js'));
-          resultFiles.indexOf('fixtures/circular3.js').should.be.above(resultFiles.indexOf('fixtures/circular.js'));
+          resultFiles.indexOf(path.join('fixtures','module-controller.js')).should.be.above(resultFiles.indexOf(path.join('fixtures','module.js')));
+          resultFiles.indexOf(path.join('fixtures','module.js')).should.be.above(resultFiles.indexOf(path.join('fixtures','circular.js')));
+          resultFiles.indexOf(path.join('fixtures','circular3.js')).should.be.above(resultFiles.indexOf(path.join('fixtures','circular2.js')));
+          resultFiles.indexOf(path.join('fixtures','circular3.js')).should.be.above(resultFiles.indexOf(path.join('fixtures','circular.js')));
           done();
       })
   });
@@ -93,7 +93,7 @@ describe('gulp-angular-filesort', function () {
 
     sort(files, function (resultFiles) {
       resultFiles.length.should.equal(1);
-      resultFiles[0].should.equal('fixtures/circular.js');
+      resultFiles[0].should.equal(path.join('fixtures','circular.js'));
       done();
     })
   });
@@ -106,8 +106,8 @@ describe('gulp-angular-filesort', function () {
 
     sort(files, function (resultFiles) {
       resultFiles.length.should.equal(2);
-      resultFiles.should.contain('fixtures/circular2.js');
-      resultFiles.should.contain('fixtures/circular3.js');
+      resultFiles.should.contain(path.join('fixtures','circular2.js'));
+      resultFiles.should.contain(path.join('fixtures','circular3.js'));
       done();
     })
   });
@@ -130,7 +130,7 @@ describe('gulp-angular-filesort', function () {
     ];
 
     sort(files, function (resultFiles) {
-      resultFiles.should.eql(['fixtures/empty.js'])
+      resultFiles.should.eql([path.join('fixtures','empty.js')])
       done();
     })
   });

--- a/test/angularFilesort_test.js
+++ b/test/angularFilesort_test.js
@@ -2,14 +2,14 @@
 /* global describe, it */
 var chai = require('chai'),
   should = chai.should(),
-  gutil = require('gulp-util'),
+  Vinyl = require('vinyl'),
   fs = require('fs'),
   path = require('path'),
   angularFilesort = require('../.');
 
 function fixture(file, config) {
   var filepath = path.join(__dirname, file);
-  return new gutil.File({
+  return new Vinyl({
     path: filepath,
     cwd: __dirname,
     base: __dirname,


### PR DESCRIPTION
Closes #55.

In passing, I made the tests compatible with Windows.